### PR TITLE
changed BaseException to Exception

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": false
+        "source.organizeImports": "never"
     },
     "python.testing.autoTestDiscoverOnSaveEnabled": true
 }

--- a/cl200a_controller/cl200a_utils.py
+++ b/cl200a_controller/cl200a_utils.py
@@ -19,19 +19,19 @@ from typing import List, Tuple, Union
 from serial import EIGHTBITS, PARITY_NONE, STOPBITS_ONE, Serial, SerialException
 
 
-class MeasurementValueOverError(BaseException):
+class MeasurementValueOverError(Exception):
     pass
 
 
-class LowLuminanceError(BaseException):
+class LowLuminanceError(Exception):
     pass
 
 
-class LowBatteryError(BaseException):
+class LowBatteryError(Exception):
     pass
 
 
-class ValueOutOfRangeError(BaseException):
+class ValueOutOfRangeError(Exception):
     pass
 
 


### PR DESCRIPTION
According to the standard rule in Python, the custom exception should be inherited from Exception.
There is 1 change in the VSCode setting but probably due to the VSCode version difference.